### PR TITLE
feat: Add command list to IAggregate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2740,7 +2740,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3155,7 +3156,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3211,6 +3213,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3254,12 +3257,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/domain/Aggregate.ts
+++ b/src/domain/Aggregate.ts
@@ -55,6 +55,7 @@ export function createAggregate<T>(
   return {
     applyCommand,
     rehydrate,
+    commands: Object.keys(commands),
     name: aggregateName
   };
 }

--- a/src/domain/__tests__/Aggregate.spec.ts
+++ b/src/domain/__tests__/Aggregate.spec.ts
@@ -1,16 +1,21 @@
-import atest, { TestInterface } from 'ava';
-
 import './_helpers';
 
 import { createCommand } from '../Command';
 import { makeVersionedEntity } from '../Entity';
 import { createEvent } from '../Event';
-import { IAggregate } from '../interfaces';
 
 /* tslint:disable-next-line no-duplicate-imports */
-import { ICounter } from './_helpers';
+import { test } from './_helpers';
 
-const test = atest as TestInterface<{ aggregate: IAggregate<ICounter> }>;
+test('name', t => {
+  const { aggregate, definition } = t.context;
+  t.is(aggregate.name, definition.name);
+});
+
+test('commands', t => {
+  const { aggregate } = t.context;
+  t.deepEqual(aggregate.commands, ['increment', 'incrementMultiple', 'noop']);
+});
 
 test('rehydrate', t => {
   const { aggregate } = t.context;

--- a/src/domain/__tests__/_helpers.ts
+++ b/src/domain/__tests__/_helpers.ts
@@ -1,12 +1,25 @@
 /* tslint:disable-next-line no-var-requires */
-const test = require('ninos')(require('ava'));
+const aTest = require('ninos')(require('ava'));
+import { TestInterface } from 'ava';
 
 import { createAggregate } from '../Aggregate';
-import { IAggregateDefinition } from '../interfaces';
+import {
+  IAggregate,
+  IAggregateDefinition,
+  IRejectFunction
+} from '../interfaces';
 
 const initialState = {
   value: 0
 };
+
+export const test = aTest as TestInterface<{
+  aggregate: IAggregate<ICounter>;
+  definition: IAggregateDefinition<ICounter>;
+  initialState: ICounter;
+  reject: IRejectFunction;
+  stub: () => any;
+}>;
 
 const definition: IAggregateDefinition<ICounter> = {
   initialState,
@@ -38,7 +51,7 @@ const definition: IAggregateDefinition<ICounter> = {
 
 export const aggregate = createAggregate<ICounter>(definition);
 
-test.beforeEach((t: any) => {
+test.beforeEach(t => {
   t.context = {
     ...t.context,
     aggregate,

--- a/src/domain/interfaces.ts
+++ b/src/domain/interfaces.ts
@@ -79,6 +79,7 @@ export interface IAggregateDefinition<T> {
 
 export interface IAggregate<T> {
   readonly name: string;
+  readonly commands: string[];
   rehydrate: (
     events: IDomainEvent[],
     snapshot?: IVersionedEntity<T>


### PR DESCRIPTION
Provide a list of commands available on an Aggregate instance using the keys of the `commands` definition