### PR TITLE
feat: Concurrency error handling

### DIFF
--- a/packages/eventstore/src/index.ts
+++ b/packages/eventstore/src/index.ts
@@ -1,6 +1,8 @@
 export * from './interfaces';
 export * from './constants';
 
+export { AppendOnlyStoreConcurrencyError } from './storage';
+
 import EventStore from './EventStore';
 
 import FileEventStore from './FileEventStore';

--- a/packages/eventstore/src/storage/errors.ts
+++ b/packages/eventstore/src/storage/errors.ts
@@ -1,7 +1,15 @@
 export class AppendOnlyStoreConcurrencyError extends Error {
+  public streamId: string;
+  public expectedVersion: number;
+  public actualVersion: number;
+
   constructor(streamId: string, version: number, actualVersion: number) {
     const msg = `Expected stream "${streamId}" to be at version ${version}, got ${actualVersion}`;
     super(msg);
+
     this.name = this.constructor.name;
+    this.streamId = streamId;
+    this.expectedVersion = version;
+    this.actualVersion = actualVersion;
   }
 }

--- a/packages/repository/src/Repository.test.ts
+++ b/packages/repository/src/Repository.test.ts
@@ -1,0 +1,163 @@
+import {
+  createAggregateRoot,
+  createEvent,
+  IAggregateDefinition
+} from '@eskit/core';
+
+import { IEventStore, InMemoryStore } from '@eskit/eventstore';
+
+import { ConcurrentModificationError } from './errors';
+import { IRepository } from './interfaces';
+import Repository from './Repository';
+
+interface ICounter {
+  name: string;
+  value: number;
+}
+
+const definition: IAggregateDefinition<ICounter> = {
+  commands: {
+    changeName: (entity, { data: { to } }) => {
+      entity.publish('nameChanged', { to });
+    },
+    increment: entity => {
+      entity.publish('incremented');
+    }
+  },
+  initialState: { name: 'defaultCounter', value: 0 },
+  name: 'counter',
+  reducer: {
+    incremented: state => ({
+      ...state,
+      value: state.value + 1
+    }),
+    nameChanged: (state, { data: { to } }) => ({
+      ...state,
+      name: to
+    })
+  }
+};
+
+const counter = createAggregateRoot<ICounter>(definition);
+
+describe('Repository', () => {
+  let eventStore: IEventStore;
+  let repository: IRepository<ICounter>;
+
+  const incrementEvents = [
+    createEvent('incremented'),
+    createEvent('incremented'),
+    createEvent('incremented')
+  ];
+
+  beforeEach(() => {
+    eventStore = new InMemoryStore({ context: 'counting' });
+    repository = new Repository(counter, eventStore);
+  });
+
+  it('Should save events to underlying store', async () => {
+    // Save the events to the repository under the id "abcdef"
+    await repository.save('abcdef', incrementEvents, 0);
+
+    const savedEvents = await eventStore.loadEvents({
+      id: 'abcdef',
+      name: 'counter'
+    });
+
+    expect(savedEvents.length).toBe(3);
+  });
+
+  it('Should reconstruct aggregate state from a saved event stream', async () => {
+    // Save the events to the repository under the id "abcdef"
+    await repository.save('abcdef', incrementEvents, 0);
+
+    // Load the state of the aggregate from the repository
+    const repositoryState = await repository.getById('abcdef');
+
+    // Replay the events through the aggregate directly
+    const expectedState = counter.rehydrate('abcdef', incrementEvents);
+
+    expect(repositoryState).toStrictEqual(expectedState);
+  });
+
+  it('Should generate unique identifiers for new aggregate instances (UUIDs)', async () => {
+    const ids = await Promise.all(
+      new Array(15).fill(undefined).map(() => repository.getNextId())
+    );
+
+    // Collect the list of unique ids by converting to an object using them as keys
+    const uniqueIds = Object.keys(
+      ids.reduce(
+        (prev: { [s: string]: undefined }, id) => ({
+          ...prev,
+          [id]: undefined
+        }),
+        {}
+      )
+    );
+
+    // Duplicate ids will have been dropped in the conversion to an object and back
+    expect(ids.length).toBe(uniqueIds.length);
+  });
+
+  describe('concurrency error handling', () => {
+    const counterWithErrorHandling = createAggregateRoot({
+      ...definition,
+      concurrencyErrorResolver: ({ newEvents, savedEvents }) => {
+        // Allow events of different types to be applied concurrently
+        const savedEventTypes = savedEvents.map(e => e.name);
+
+        let typesOverlap = false;
+        newEvents.forEach(
+          e => (typesOverlap = typesOverlap || savedEventTypes.includes(e.name))
+        );
+
+        // If we're applying events of the same type then reject
+        if (typesOverlap) {
+          return false;
+        }
+
+        return newEvents;
+      }
+    });
+
+    let updatedRepository: Repository<ICounter>;
+
+    beforeEach(() => {
+      updatedRepository = new Repository(counterWithErrorHandling, eventStore);
+    });
+
+    it('Should throw a `ConcurrentModificationError`` if an `AppendOnlyStoreConcurrencyError` is thrown and handling logic is not present', async () => {
+      await repository.save('abcdef', incrementEvents, 0);
+      const shouldThrow = () => repository.save('abcdef', incrementEvents, 0);
+      await expect(shouldThrow()).rejects.toThrow(ConcurrentModificationError);
+    });
+
+    it('Should be able to recover from `AppendOnlyStoreConcurrencyError` exceptions if logic is present in the aggregate', async () => {
+      await updatedRepository.save('abcdef', incrementEvents, 0);
+      await updatedRepository.save(
+        'abcdef',
+        [createEvent('nameChanged', { to: 'updatedName' })],
+        0
+      );
+      const aggregate = await repository.getById('abcdef');
+
+      // Should have appended the increment events onto existing aggregate state
+      expect(aggregate.version).toBe(incrementEvents.length + 1);
+
+      // Should have correctly updated the state
+      expect(aggregate.state).toMatchObject({
+        name: 'updatedName',
+        value: 3
+      });
+    });
+
+    it('Should throw a `ConcurrentModificationError` if the concurrency handling logic rejects the changes', async () => {
+      await updatedRepository.save('abcdef', incrementEvents, 0);
+
+      // Saving events of the same type is not permitted by logic within `resolveConcurrencyErrors', so version mismatch should raise error
+      const shouldThrow = () => repository.save('abcdef', incrementEvents, 0);
+      await expect(shouldThrow()).rejects.toThrow(ConcurrentModificationError);
+    });
+  });
+});

--- a/packages/repository/src/Repository.ts
+++ b/packages/repository/src/Repository.ts
@@ -1,15 +1,23 @@
+import debugModule from 'debug';
 import { inject, injectable } from 'inversify';
 import uuid from 'uuid';
 
 import {
-  IAggregateEvent,
   IAggregateIdentifier,
   IAggregateRoot,
   IAggregateState,
   IDomainEvent
 } from '@eskit/core';
-import { IEventStore, TYPES } from '@eskit/eventstore';
+import {
+  AppendOnlyStoreConcurrencyError,
+  IEventStore,
+  TYPES
+} from '@eskit/eventstore';
+
+import { ConcurrentModificationError } from './errors';
 import { IRepository } from './interfaces';
+
+const debug = debugModule('eskit:repository:Repository');
 
 @injectable()
 class Repository<T> implements IRepository<T> {
@@ -31,7 +39,21 @@ class Repository<T> implements IRepository<T> {
     metadata?: object
   ) {
     const aggregateId = this._getAggregateId(id);
-    return this._store.save(aggregateId, events, version, metadata);
+    try {
+      return await this._store.save(aggregateId, events, version, metadata);
+    } catch (e) {
+      if (e instanceof AppendOnlyStoreConcurrencyError) {
+        await this._handleConcurrencyError({
+          aggregateId,
+          events,
+          metadata,
+          actualVersion: e.actualVersion,
+          expectedVersion: version
+        });
+      } else {
+        throw e;
+      }
+    }
   }
 
   public async getById(id: string): Promise<IAggregateState<T>> {
@@ -50,10 +72,51 @@ class Repository<T> implements IRepository<T> {
 
   private _createInstance(
     id: string,
-    events: IAggregateEvent[]
+    events: IDomainEvent[]
   ): IAggregateState<T> {
     const { state, version } = this._aggregate.rehydrate(id, events);
     return { id, state, version, exists: version > 0 };
+  }
+
+  private async _handleConcurrencyError({
+    actualVersion,
+    aggregateId,
+    events,
+    metadata,
+    expectedVersion
+  }: {
+    actualVersion: number;
+    aggregateId: IAggregateIdentifier;
+    events: IDomainEvent[];
+    expectedVersion: number;
+    metadata?: object;
+  }) {
+    debug(`Handling concurrency error for ${aggregateId.name}`);
+
+    const actualState = await this.getById(aggregateId.id);
+    const expectedState = this._createInstance(aggregateId.id, events);
+
+    const savedEvents = await this._store.loadEvents(
+      aggregateId,
+      expectedVersion
+    );
+
+    const resolveResult = this._aggregate.resolveConcurrencyError({
+      actualState,
+      expectedState,
+      savedEvents,
+      newEvents: events
+    });
+
+    if (!resolveResult) {
+      throw new ConcurrentModificationError(
+        aggregateId,
+        actualVersion,
+        expectedVersion
+      );
+    } else {
+      await this.save(aggregateId.id, resolveResult, actualVersion, metadata);
+    }
   }
 }
 

--- a/packages/repository/src/errors.ts
+++ b/packages/repository/src/errors.ts
@@ -1,0 +1,13 @@
+import { IAggregateIdentifier } from '@eskit/core';
+
+export class ConcurrentModificationError extends Error {
+  constructor(
+    aggregateId: IAggregateIdentifier,
+    actualVersion: number,
+    expectedVersion: number
+  ) {
+    const { id, name } = aggregateId;
+    const msg = `Expected aggregate ${name}:${id} to be at version ${expectedVersion}, got ${actualVersion}`;
+    super(msg);
+  }
+}


### PR DESCRIPTION
Optional argument `concurrencyErrorResolver` on aggregate definitions
allows for silent handling of concurrency errors where these are
recoverable

Closes #18